### PR TITLE
Slightly more helpful missing key error

### DIFF
--- a/mibidata/mibi_image.py
+++ b/mibidata/mibi_image.py
@@ -487,9 +487,26 @@ class MibiImage():
                     f'with targets only (no masses were given), available ' \
                     f'targets are {self._channels}'
             else:
-                error_msg = f'Subset of channels, targets or massses not ' \
-                    f'found matching {channels}, available targets are ' \
-                    f'{self._channels}'
+                missing_channels = []
+                matches = []                
+                keys = [channel[1] for channel in self._channels]
+                
+                # check for missing channels
+                # match on case-insensitive substring
+                for channel in channels:
+                    if channel in keys or len(channel)<3:                    
+                        continue
+                    missing_channels.append(channel)
+                    matches += [match for match in keys if channel.lower() in \
+                        match.lower()]
+                                
+                error_msg = f'Channels, targets or masses not found ' \
+                    f'matching {missing_channels}. '
+
+                if len(matches):
+                    error_msg += f'Did you mean {matches}? '
+                    
+                error_msg += f'Available targets are {keys}.'
             raise KeyError(error_msg)
 
     def slice_data(self, channels):


### PR DESCRIPTION
When key errors are present, show which keys did not match. Also, suggest potential matches ("Did you mean... ?") based on case-insensitive substrings.

This could be particularly helpful when there are many channels to browse through.

**Example**
image_id = request.image_id('191001_cohort', 'Point3')
image = request.get_mibi_image(image_id)
rgb = image[['nakatpase', 'GLUT1']]

KeyError: "Channels, targets or masses not found matching ['nakatpase', 'GLUT1']. Did you mean ['175_NaKATPase', '166_GLUT1']? Available targets are ['089_H3', '113_vimentin', '115_SMA', '141_CD98', '142_NRF2p', '143_CD4', '144_CD14', '145_CD45', '147_PD1', '148_CD31', '150_SDHA', '151_Ki67', '153_CS', '154_S6p', '155_CD11c', '156_CD68', '157_CD36', '158_ATP5A', '159_CD3', '160_CD39', '161_VDAC1', '162_G6PD', '163_XBP1', '164_PKM2', '165_ASCT2', '166_GLUT1', '167_CD8', '168_CD57', '169_LDHA', '170_IDH2', '171_HK1', '172_Ecad', '173_CPT1A', '174_CK', '175_NaKATPase', '176_HIF1A']."